### PR TITLE
Add refresh token support and refresh endpoint

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -7,6 +7,7 @@ class Settings(BaseSettings):
     secret_key: str = Field("dev", alias="SECRET_KEY")
     algorithm: str = Field("HS256", alias="ALGORITHM")
     access_token_expire_minutes: int = Field(60, alias="ACCESS_TOKEN_EXPIRE_MINUTES")
+    refresh_token_expire_days: int = Field(7, alias="REFRESH_TOKEN_EXPIRE_DAYS")
     database_url: str = Field("sqlite:///./taskmanager.db", alias="DATABASE_URL")
 
     admin_email: str | None = Field(None, alias="ADMIN_EMAIL")

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -6,6 +6,9 @@ from app.core.config import get_settings
 settings = get_settings()
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
+# In-memory store for revoked refresh tokens
+revoked_refresh_tokens: set[str] = set()
+
 def hash_password(p: str) -> str:
     return pwd_context.hash(p)
 
@@ -20,3 +23,26 @@ def create_access_token(sub: str, minutes: int | None = None) -> str:
 def decode_token(token: str) -> str:
     payload = jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
     return str(payload.get("sub"))
+
+def create_refresh_token(sub: str, days: int | None = None) -> str:
+    exp_days = days or settings.refresh_token_expire_days
+    payload = {
+        "sub": sub,
+        "type": "refresh",
+        "exp": datetime.utcnow() + timedelta(days=exp_days),
+    }
+    return jwt.encode(payload, settings.secret_key, algorithm=settings.algorithm)
+
+def decode_refresh_token(token: str) -> str:
+    payload = jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
+    if payload.get("type") != "refresh":
+        raise JWTError("Invalid token type")
+    return str(payload.get("sub"))
+
+def verify_refresh_token(token: str) -> str:
+    if token in revoked_refresh_tokens:
+        raise JWTError("Token revoked")
+    return decode_refresh_token(token)
+
+def revoke_refresh_token(token: str) -> None:
+    revoked_refresh_tokens.add(token)

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -1,11 +1,19 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm
+from jose import JWTError
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 from app.core.database import get_db
-from app.core.security import hash_password, verify_password, create_access_token
+from app.core.security import (
+    hash_password,
+    verify_password,
+    create_access_token,
+    create_refresh_token,
+    verify_refresh_token,
+    revoke_refresh_token,
+)
 from app.models.user import User, Role
-from app.schemas.user import UserCreate, Token
+from app.schemas.user import UserCreate, Token, TokenRefresh
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -29,5 +37,17 @@ def login(form: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get
     user = db.scalar(select(User).where(User.email == form.username))
     if not user or not verify_password(form.password, user.hashed_password):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
-    token = create_access_token(sub=str(user.id))
-    return {"access_token": token, "token_type": "bearer"}
+    access = create_access_token(sub=str(user.id))
+    refresh = create_refresh_token(sub=str(user.id))
+    return {"access_token": access, "refresh_token": refresh, "token_type": "bearer"}
+
+@router.post("/refresh", response_model=Token)
+def refresh(payload: TokenRefresh):
+    try:
+        sub = verify_refresh_token(payload.refresh_token)
+    except JWTError:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid refresh token")
+    revoke_refresh_token(payload.refresh_token)
+    access = create_access_token(sub=sub)
+    new_refresh = create_refresh_token(sub=sub)
+    return {"access_token": access, "refresh_token": new_refresh, "token_type": "bearer"}

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -20,4 +20,8 @@ class UserOut(UserBase):
 
 class Token(BaseModel):
     access_token: str
+    refresh_token: str
     token_type: str = "bearer"
+
+class TokenRefresh(BaseModel):
+    refresh_token: str


### PR DESCRIPTION
## Summary
- add refresh token creation/verification utilities with revocation list
- include refresh tokens in token schema and login response
- expose `/auth/refresh` to issue new access tokens

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cd6d3713883229086a64279297770