### PR TITLE
Add pagination support for tasks and notifications

### DIFF
--- a/app/routers/notifications.py
+++ b/app/routers/notifications.py
@@ -1,7 +1,7 @@
-from typing import List
+from typing import List, Annotated
 from datetime import datetime
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy import select, update
 from sqlalchemy.orm import Session
 
@@ -18,12 +18,16 @@ router = APIRouter(prefix="/notifications", tags=["notifications"])
 def list_my_notifications(
     db: Session = Depends(get_db),
     current: User = Depends(get_current_user),
+    limit: Annotated[int, Query(ge=1, le=1000, description="Maximum number of notifications to return")] = 100,
+    offset: Annotated[int, Query(ge=0, description="Number of notifications to skip")] = 0,
 ):
     rows = (
         db.execute(
             select(Notification)
             .where(Notification.user_id == current.id)
             .order_by(Notification.id.desc())
+            .limit(limit)
+            .offset(offset)
         )
         .scalars()
         .all()

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,76 @@
+import os
+import sys
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# Ensure the app package is on the import path
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from app.core.database import Base
+from app.core.security import hash_password
+from app.models.user import User, Role
+from app.models.task import Task
+from app.models.notification import Notification
+from app.routers.tasks import list_tasks
+from app.routers.notifications import list_my_notifications
+
+
+def setup_session():
+    engine = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    TestingSessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, future=True)
+    Base.metadata.create_all(bind=engine)
+    return TestingSessionLocal
+
+
+def test_task_pagination():
+    SessionLocal = setup_session()
+    with SessionLocal() as db:
+        user = User(
+            email="user@example.com",
+            full_name="Test User",
+            hashed_password=hash_password("pass"),
+            role=Role.user,
+        )
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        for i in range(3):
+            db.add(Task(title=f"task-{i}", assignee_id=user.id))
+        db.commit()
+
+        res = list_tasks(db=db, current=user, limit=2)
+        assert len(res) == 2
+        assert res[0].title == "task-0"
+        assert res[1].title == "task-1"
+
+        res = list_tasks(db=db, current=user, limit=2, offset=1)
+        assert len(res) == 2
+        assert res[0].title == "task-1"
+        assert res[1].title == "task-2"
+
+
+def test_notification_pagination():
+    SessionLocal = setup_session()
+    with SessionLocal() as db:
+        user = User(
+            email="user@example.com",
+            full_name="Test User",
+            hashed_password=hash_password("pass"),
+            role=Role.user,
+        )
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        for i in range(3):
+            db.add(Notification(user_id=user.id, message=f"note-{i}"))
+        db.commit()
+
+        res = list_my_notifications(db=db, current=user, limit=2)
+        assert [n.message for n in res] == ["note-2", "note-1"]
+
+        res = list_my_notifications(db=db, current=user, limit=1, offset=2)
+        assert len(res) == 1
+        assert res[0].message == "note-0"


### PR DESCRIPTION
## Summary
- add `limit` and `offset` query params to tasks and notifications list endpoints
- paginate SQLAlchemy queries to support result slicing
- include tests covering task and notification pagination

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cd6d251bc8322823b5ee70a1cbb17