### PR TITLE
Add pytest tests and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ python-multipart
 pydantic-settings
 email-validator
 alembic
+pytest
+httpx

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,57 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.core import database
+from app.core.database import Base, get_db
+from app.routers import auth, users, tasks, notifications
+
+# Set up in-memory SQLite database
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+# Override the application's database with the testing one
+
+database.engine = engine
+database.SessionLocal = TestingSessionLocal
+Base.metadata.create_all(bind=engine)
+
+
+@pytest.fixture
+def db_session():
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = TestingSessionLocal(bind=connection)
+    try:
+        yield session
+    finally:
+        session.close()
+        transaction.rollback()
+        connection.close()
+
+
+@pytest.fixture
+def client(db_session):
+    app = FastAPI()
+    app.include_router(auth.router)
+    app.include_router(users.router)
+    app.include_router(tasks.router)
+    app.include_router(notifications.router)
+
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    with TestClient(app) as c:
+        yield c

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,23 @@
+from fastapi.testclient import TestClient
+
+
+def test_signup_login(client: TestClient):
+    payload = {
+        "email": "user@example.com",
+        "full_name": "Test User",
+        "password": "secret",
+    }
+    res = client.post("/auth/signup", json=payload)
+    assert res.status_code == 201
+
+    res = client.post(
+        "/auth/login",
+        data={"username": payload["email"], "password": payload["password"]},
+    )
+    assert res.status_code == 200
+    token = res.json()["access_token"]
+    assert token
+
+    me = client.get("/users/me", headers={"Authorization": f"Bearer {token}"})
+    assert me.status_code == 200
+    assert me.json()["email"] == payload["email"]

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,53 +1,42 @@
-from datetime import datetime
-import os
-import sys
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.pool import StaticPool
+from fastapi.testclient import TestClient
+from sqlalchemy import select
 
-# Ensure the app package is on the import path
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-
-from app.core.database import Base
-from app.core.security import hash_password
-from app.models.user import User, Role
+from app.models.user import User
 from app.models.notification import Notification
-from app.routers.notifications import list_my_notifications, mark_read
 
 
-def setup_session():
-    engine = create_engine(
-        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+def auth_headers(client: TestClient):
+    payload = {
+        "email": "user@example.com",
+        "full_name": "Test User",
+        "password": "secret",
+    }
+    client.post("/auth/signup", json=payload)
+    res = client.post(
+        "/auth/login",
+        data={"username": payload["email"], "password": payload["password"]},
     )
-    TestingSessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, future=True)
-    Base.metadata.create_all(bind=engine)
-    return TestingSessionLocal
+    token = res.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
 
 
-def test_read_status_flow():
-    SessionLocal = setup_session()
-    with SessionLocal() as db:
-        user = User(
-            email="user@example.com",
-            full_name="Test User",
-            hashed_password=hash_password("pass"),
-            role=Role.user,
-        )
-        db.add(user)
-        db.commit()
-        db.refresh(user)
-        note = Notification(user_id=user.id, message="hello")
-        db.add(note)
-        db.commit()
-        db.refresh(note)
+def test_notification_read_flow(client: TestClient, db_session):
+    headers = auth_headers(client)
+    user = db_session.scalar(select(User).where(User.email == "user@example.com"))
+    note = Notification(user_id=user.id, message="hello")
+    db_session.add(note)
+    db_session.commit()
+    db_session.refresh(note)
 
-        res = list_my_notifications(db=db, current=user)
-        assert len(res) == 1
-        notif = res[0]
-        assert isinstance(notif.created_at, datetime)
-        assert notif.read_at is None
+    res = client.get("/notifications/", headers=headers)
+    assert res.status_code == 200
+    data = res.json()
+    assert len(data) == 1
+    assert data[0]["read_at"] is None
 
-        mark_read(notification_id=note.id, db=db, current=user)
+    res = client.post(f"/notifications/{note.id}/read", headers=headers)
+    assert res.status_code == 204
 
-        res = list_my_notifications(db=db, current=user)
-        assert res[0].read_at is not None
+    res = client.get("/notifications/", headers=headers)
+    assert res.status_code == 200
+    assert res.json()[0]["read_at"] is not None

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,49 @@
+from fastapi.testclient import TestClient
+
+
+def auth_headers(client: TestClient):
+    payload = {
+        "email": "user@example.com",
+        "full_name": "Test User",
+        "password": "secret",
+    }
+    client.post("/auth/signup", json=payload)
+    res = client.post(
+        "/auth/login",
+        data={"username": payload["email"], "password": payload["password"]},
+    )
+    token = res.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_task_crud_flow(client: TestClient):
+    headers = auth_headers(client)
+
+    # Create
+    res = client.post("/tasks/", json={"title": "Task 1"}, headers=headers)
+    assert res.status_code == 201
+    task_id = res.json()["id"]
+
+    # Read
+    res = client.get(f"/tasks/{task_id}", headers=headers)
+    assert res.status_code == 200
+    assert res.json()["title"] == "Task 1"
+
+    # Update
+    res = client.patch(
+        f"/tasks/{task_id}",
+        json={"status": "in_progress", "progress": 50},
+        headers=headers,
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["status"] == "in_progress"
+    assert body["progress"] == 50
+
+    # Delete
+    res = client.delete(f"/tasks/{task_id}", headers=headers)
+    assert res.status_code == 204
+
+    # Confirm deletion
+    res = client.get(f"/tasks/{task_id}", headers=headers)
+    assert res.status_code == 404


### PR DESCRIPTION
## Summary
- configure pytest for the project
- add fixtures for in-memory DB and FastAPI TestClient
- cover auth, task CRUD and notification read flows
- run tests in GitHub Actions

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement httpx)*
- `pytest` *(fails: RuntimeError: The starlette.testclient module requires the httpx package to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_689cd6d479a08322ba674b9a65a01b80